### PR TITLE
fix: cd workflow url notification

### DIFF
--- a/.github/workflows/cd-frontend.yaml
+++ b/.github/workflows/cd-frontend.yaml
@@ -76,7 +76,6 @@ jobs:
           # Use absolute path to avoid confusion with root directory
           DEPLOY_DIR="$(pwd)/out"
           echo "Deploying from: $DEPLOY_DIR"
-          ls -la "$DEPLOY_DIR" || echo "Directory not found!"
 
           SITE_ID="${{ secrets.NETLIFY_SITE_ID }}"
           AUTH_TOKEN="${{ secrets.NETLIFY_AUTH_TOKEN }}"
@@ -103,6 +102,11 @@ jobs:
           # Parse JSON output
           DEPLOY_URL=$(echo "$OUTPUT" | jq -r '.deploy_url')
           LOGS_URL=$(echo "$OUTPUT" | jq -r '.logs_url')
+
+          # Use main URL for Production
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            DEPLOY_URL=$(echo "$OUTPUT" | jq -r '.url')
+          fi
 
           echo "DEPLOY_URL=$DEPLOY_URL" >> $GITHUB_ENV
           echo "LOGS_URL=$LOGS_URL" >> $GITHUB_ENV


### PR DESCRIPTION
## 概要
CDワークフローの通知URLロジックを修正しました。

## 変更点
- **Production通知**: デプロイごとの固定URLではなく、メインのサイトURL (https://smart-food-logger.netlify.app) を通知するように変更。
- **デバッグ削除**: 不要になった ls -la コマンドを削除。

## 目的
Productionデプロイ完了時に、ユーザーがアクセスすべき正しいURLを通知するため。