### PR TITLE
chore: update .env.local.example and rename backend webhook variable

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -17,10 +17,13 @@ NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID="YOUR_FIREBASE_MEASUREMENT_ID"
 # @see https://dev.fitbit.com/build/reference/web-api/developer-guide/getting-started/#Registering-an-Application
 #############################
 NEXT_PUBLIC_FITBIT_CLIENT_ID="YOUR_FITBIT_CLIENT_ID"
-# FitBitに登録したアプリの"Redirect URL"と一致
-NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI="YOUR_FITBIT_BACKEND_REDIRECT_URI"
-NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI="YOUR_FITBIT_FRONTEND_REDIRECT_URI"
-NEXT_PUBLIC_FITBIT_API_ENDPOINT="NEXT_PUBLIC_FITBIT_API_ENDPOINT"
+# Fitbitに登録したアプリの "Redirect URL" と一致させる必要があります
+NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI="http://localhost:3000/api/fitbit/callback"
+NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI="http://localhost:3000/oauth"
+# Backend APIのWebhookエンドポイント
+# E2Eテストや、ローカルでモックサーバーを使用する場合に変更します
+# 本番APIを使用する場合は "https://oauth.vivviv.net/fitbit-auth-webhook" 等を設定
+BACKEND_FITBIT_WEBHOOK_URL="http://localhost:3000/api/fitbit/callback"
 
 #############################
 # Google reCAPTCHA
@@ -29,12 +32,17 @@ NEXT_PUBLIC_FITBIT_API_ENDPOINT="NEXT_PUBLIC_FITBIT_API_ENDPOINT"
 # Google reCAPTCHAのテスト用キー（localhostでも動作します）
 NEXT_PUBLIC_RECAPTCHA_SITE_KEY="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
 
-# other
-ENVIRONMENT="local"
-NEXT_PUBLIC_MOCK_AUTH="true"
-DISCORD_WEBHOOK_URL="notify discord"
-NEXT_PUBLIC_PORTAL_URL="http://localhost:3000"
+#############################
+# App Configuration
+#############################
+# アプリケーションの環境 (local, staging, preview, ci-test, PROD)
+# layout.tsx, utils/environment.ts 等で使用されます
+# ヘッダーの色などが変わります (local=青, staging=黄, PROD=グレー)
+APP_ENVIRONMENT="local"
 
-#############################
-# Deployment Configuration
-#############################
+# 認証モック (true にすると認証をバイパスします)
+# 開発中にFirebase認証をスキップしたい場合に使用してください
+# NEXT_PUBLIC_MOCK_AUTH="true"
+
+# Discord Webhook (デプロイ通知用 - ローカル開発では通常不要)
+DISCORD_WEBHOOK_URL=""

--- a/frontend/src/app/actions/fitbitLog.ts
+++ b/frontend/src/app/actions/fitbitLog.ts
@@ -6,10 +6,10 @@ import {
 } from "@smart-food-logger/shared";
 
 export async function logToFitbit(data: unknown, idToken: string) {
-  const API_ENDPOINT = process.env.FITBIT_API_ENDPOINT;
+  const API_ENDPOINT = process.env.BACKEND_FITBIT_WEBHOOK_URL;
 
   if (!API_ENDPOINT) {
-    console.error("FITBIT_API_ENDPOINT is not defined");
+    console.error("BACKEND_FITBIT_WEBHOOK_URL is not defined");
     return {
       success: false,
       message: "サーバー設定エラー: APIエンドポイントが設定されていません。",

--- a/frontend/test/cypress/e2e/ux-improvement.cy.ts
+++ b/frontend/test/cypress/e2e/ux-improvement.cy.ts
@@ -58,7 +58,7 @@ describe("UX Improvement Tests for Smart Food Logger AI", () => {
       // API通信をモック
       cy.intercept(
         "POST",
-        process.env.NEXT_PUBLIC_FITBIT_API_ENDPOINT || "**/fitbit-api-logic",
+        process.env.BACKEND_FITBIT_WEBHOOK_URL || "**/fitbit-api-logic",
         {
           statusCode: 200,
           body: { message: "Fitbitへの記録が完了しました！" },

--- a/frontend/test/playwright/e2e/smoke-health.spec.ts
+++ b/frontend/test/playwright/e2e/smoke-health.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 test.describe("バックエンドヘルスチェック", () => {
   test("GCPバックエンドが正常に応答すること", async ({ request }) => {
-    const apiEndpoint = process.env.NEXT_PUBLIC_FITBIT_API_ENDPOINT;
+    const apiEndpoint = process.env.BACKEND_FITBIT_WEBHOOK_URL;
 
     if (!apiEndpoint || apiEndpoint.startsWith("http://localhost")) {
       test.skip();


### PR DESCRIPTION
## 概要
ローカル開発用の環境変数定義ファイル (rontend/.env.local.example) を最新化し、変数名を適切に変更しました。

## 変更内容
- rontend/.env.local.example の更新（日本語コメント、アプリ設定変数追加）
- FITBIT_API_ENDPOINT を BACKEND_FITBIT_WEBHOOK_URL にリネーム（Server Action, テスト, Netlify設定）
- NEXT_PUBLIC_PORTAL_URL の削除

## 確認方法
- rontend/.env.local.example の内容確認
- CI (Unit Test) が通過すること