### PR TITLE
refactor: Terraform変数の明示的定義への変更

### DIFF
--- a/infra/00_common/netlify.tf
+++ b/infra/00_common/netlify.tf
@@ -1,7 +1,25 @@
 # Generated Netlify Environment Variables based on TSV and Synced with State
 
+locals {
+  netlify_env_vars = {
+    APP_ENVIRONMENT                            = var.APP_ENVIRONMENT
+    BACKEND_FITBIT_WEBHOOK_URL                 = var.BACKEND_FITBIT_WEBHOOK_URL
+    NEXT_PUBLIC_FIREBASE_API_KEY               = var.NEXT_PUBLIC_FIREBASE_API_KEY
+    NEXT_PUBLIC_FIREBASE_APP_ID                = var.NEXT_PUBLIC_FIREBASE_APP_ID
+    NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN           = var.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN
+    NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID        = var.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
+    NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID   = var.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID
+    NEXT_PUBLIC_FIREBASE_PROJECT_ID            = var.NEXT_PUBLIC_FIREBASE_PROJECT_ID
+    NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET        = var.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET
+    NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI    = var.NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI
+    NEXT_PUBLIC_FITBIT_CLIENT_ID               = var.NEXT_PUBLIC_FITBIT_CLIENT_ID
+    NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI   = var.NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI
+    NEXT_PUBLIC_RECAPTCHA_SITE_KEY             = var.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+  }
+}
+
 resource "netlify_environment_variable" "vars" {
-  for_each = var.netlify_env_vars
+  for_each = local.netlify_env_vars
 
   team_id = var.netlify_team_id
   site_id = var.netlify_site_id

--- a/infra/00_common/variables.tf
+++ b/infra/00_common/variables.tf
@@ -8,10 +8,106 @@ variable "netlify_team_id" {
   type        = string
 }
 
-variable "netlify_env_vars" {
-  description = "Map of Netlify environment variables, where each key is a variable name and value is a list of objects with 'value' and 'context' properties (e.g., 'production', 'deploy-preview', 'branch-deploy')"
-  type = map(list(object({
+variable "APP_ENVIRONMENT" {
+  description = "Netlify Environment Variable: APP_ENVIRONMENT"
+  type = list(object({
     value   = string
     context = string
-  })))
+  }))
+}
+
+variable "BACKEND_FITBIT_WEBHOOK_URL" {
+  description = "Netlify Environment Variable: BACKEND_FITBIT_WEBHOOK_URL"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FIREBASE_API_KEY" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FIREBASE_API_KEY"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FIREBASE_APP_ID" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FIREBASE_APP_ID"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FIREBASE_PROJECT_ID" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FIREBASE_PROJECT_ID"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FITBIT_CLIENT_ID" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FITBIT_CLIENT_ID"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI"
+  type = list(object({
+    value   = string
+    context = string
+  }))
+}
+
+variable "NEXT_PUBLIC_RECAPTCHA_SITE_KEY" {
+  description = "Netlify Environment Variable: NEXT_PUBLIC_RECAPTCHA_SITE_KEY"
+  type = list(object({
+    value   = string
+    context = string
+  }))
 }

--- a/infra/10_ci/github.tf
+++ b/infra/10_ci/github.tf
@@ -1,7 +1,23 @@
 # Generated GitHub Environment Config for CI
 
+locals {
+  secrets = {
+    FITBIT_CLIENT_ID               = var.FITBIT_CLIENT_ID
+    FITBIT_CLIENT_SECRET           = var.FITBIT_CLIENT_SECRET
+    NEXT_PUBLIC_RECAPTCHA_SITE_KEY = var.NEXT_PUBLIC_RECAPTCHA_SITE_KEY
+  }
+  variables = {
+    APP_ENVIRONMENT                          = var.APP_ENVIRONMENT
+    FITBIT_BACKEND_REDIRECT_URI              = var.FITBIT_BACKEND_REDIRECT_URI
+    FITBIT_REDIRECT_URI                      = var.FITBIT_REDIRECT_URI
+    NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI  = var.NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI
+    NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI = var.NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI
+    NEXT_PUBLIC_MOCK_AUTH                    = var.NEXT_PUBLIC_MOCK_AUTH
+  }
+}
+
 resource "github_actions_environment_secret" "secrets" {
-  for_each = var.input_secrets
+  for_each = local.secrets
 
   repository      = "public-smart-food-logger"
   environment     = "ci"
@@ -10,7 +26,7 @@ resource "github_actions_environment_secret" "secrets" {
 }
 
 resource "github_actions_environment_variable" "vars" {
-  for_each = var.input_variables
+  for_each = local.variables
 
   repository    = "public-smart-food-logger"
   environment   = "ci"

--- a/infra/10_ci/variables.tf
+++ b/infra/10_ci/variables.tf
@@ -1,9 +1,12 @@
-variable "input_variables" {
-  description = "Map of GitHub environment variables"
-  type        = map(string)
-}
+# Variables
+variable "APP_ENVIRONMENT"                          { type = string }
+variable "FITBIT_BACKEND_REDIRECT_URI"              { type = string }
+variable "FITBIT_REDIRECT_URI"                      { type = string }
+variable "NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI"  { type = string }
+variable "NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI" { type = string }
+variable "NEXT_PUBLIC_MOCK_AUTH"                    { type = string }
 
-variable "input_secrets" {
-  description = "Map of GitHub environment secrets"
-  type        = map(string)
-}
+# Secrets
+variable "FITBIT_CLIENT_ID"               { type = string }
+variable "FITBIT_CLIENT_SECRET"           { type = string }
+variable "NEXT_PUBLIC_RECAPTCHA_SITE_KEY" { type = string }

--- a/infra/30_stg/github.tf
+++ b/infra/30_stg/github.tf
@@ -1,17 +1,32 @@
-resource "github_actions_environment_variable" "vars" {
-  for_each = var.input_variables
-
-  repository    = "public-smart-food-logger"
-  environment   = "staging"
-  variable_name = each.key
-  value         = each.value
+locals {
+  secrets = {
+    DISCORD_WEBHOOK_ID    = var.DISCORD_WEBHOOK_ID
+    DISCORD_WEBHOOK_TOKEN = var.DISCORD_WEBHOOK_TOKEN
+    FITBIT_CLIENT_ID      = var.FITBIT_CLIENT_ID
+    FITBIT_CLIENT_SECRET  = var.FITBIT_CLIENT_SECRET
+    FUNCTION_REGION       = var.FUNCTION_REGION
+    GCP_SA_KEY            = var.GCP_SA_KEY
+    PROJECT_ID            = var.PROJECT_ID
+  }
+  variables = {
+    FITBIT_REDIRECT_URI = var.FITBIT_REDIRECT_URI
+  }
 }
 
 resource "github_actions_environment_secret" "secrets" {
-  for_each = var.input_secrets
+  for_each = local.secrets
 
   repository      = "public-smart-food-logger"
   environment     = "staging"
   secret_name     = each.key
   plaintext_value = each.value
+}
+
+resource "github_actions_environment_variable" "vars" {
+  for_each = local.variables
+
+  repository    = "public-smart-food-logger"
+  environment   = "staging"
+  variable_name = each.key
+  value         = each.value
 }

--- a/infra/30_stg/variables.tf
+++ b/infra/30_stg/variables.tf
@@ -1,9 +1,11 @@
-variable "input_variables" {
-  description = "Map of GitHub environment variables"
-  type        = map(string)
-}
+# Variables
+variable "FITBIT_REDIRECT_URI" { type = string }
 
-variable "input_secrets" {
-  description = "Map of GitHub environment secrets"
-  type        = map(string)
-}
+# Secrets
+variable "DISCORD_WEBHOOK_ID"    { type = string }
+variable "DISCORD_WEBHOOK_TOKEN" { type = string }
+variable "FITBIT_CLIENT_ID"      { type = string }
+variable "FITBIT_CLIENT_SECRET"  { type = string }
+variable "FUNCTION_REGION"       { type = string }
+variable "GCP_SA_KEY"            { type = string }
+variable "PROJECT_ID"            { type = string }

--- a/infra/40_PROD/github.tf
+++ b/infra/40_PROD/github.tf
@@ -1,17 +1,32 @@
-resource "github_actions_environment_variable" "vars" {
-  for_each = var.input_variables
-
-  repository    = "public-smart-food-logger"
-  environment   = "production"
-  variable_name = each.key
-  value         = each.value
+locals {
+  secrets = {
+    DISCORD_WEBHOOK_ID    = var.DISCORD_WEBHOOK_ID
+    DISCORD_WEBHOOK_TOKEN = var.DISCORD_WEBHOOK_TOKEN
+    FITBIT_CLIENT_ID      = var.FITBIT_CLIENT_ID
+    FITBIT_CLIENT_SECRET  = var.FITBIT_CLIENT_SECRET
+    FUNCTION_REGION       = var.FUNCTION_REGION
+    GCP_SA_KEY            = var.GCP_SA_KEY
+    PROJECT_ID            = var.PROJECT_ID
+  }
+  variables = {
+    FITBIT_REDIRECT_URI = var.FITBIT_REDIRECT_URI
+  }
 }
 
 resource "github_actions_environment_secret" "secrets" {
-  for_each = var.input_secrets
+  for_each = local.secrets
 
   repository      = "public-smart-food-logger"
   environment     = "production"
   secret_name     = each.key
   plaintext_value = each.value
+}
+
+resource "github_actions_environment_variable" "vars" {
+  for_each = local.variables
+
+  repository    = "public-smart-food-logger"
+  environment   = "production"
+  variable_name = each.key
+  value         = each.value
 }

--- a/infra/40_PROD/variables.tf
+++ b/infra/40_PROD/variables.tf
@@ -1,9 +1,11 @@
-variable "input_variables" {
-  description = "Map of GitHub environment variables"
-  type        = map(string)
-}
+# Variables
+variable "FITBIT_REDIRECT_URI" { type = string }
 
-variable "input_secrets" {
-  description = "Map of GitHub environment secrets"
-  type        = map(string)
-}
+# Secrets
+variable "DISCORD_WEBHOOK_ID"    { type = string }
+variable "DISCORD_WEBHOOK_TOKEN" { type = string }
+variable "FITBIT_CLIENT_ID"      { type = string }
+variable "FITBIT_CLIENT_SECRET"  { type = string }
+variable "FUNCTION_REGION"       { type = string }
+variable "GCP_SA_KEY"            { type = string }
+variable "PROJECT_ID"            { type = string }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -3,16 +3,39 @@ terraform {
 }
 
 module "common" {
-  source           = "./00_common"
-  netlify_site_id  = var.netlify_site_id
-  netlify_team_id  = var.netlify_team_id
-  netlify_env_vars = var.netlify_env_vars
+  source          = "./00_common"
+  netlify_site_id = var.netlify_site_id
+  netlify_team_id = var.netlify_team_id
+
+  # Netlify Environment Variables
+  APP_ENVIRONMENT                            = var.netlify_env_vars["APP_ENVIRONMENT"]
+  BACKEND_FITBIT_WEBHOOK_URL                 = var.netlify_env_vars["BACKEND_FITBIT_WEBHOOK_URL"]
+  NEXT_PUBLIC_FIREBASE_API_KEY               = var.netlify_env_vars["NEXT_PUBLIC_FIREBASE_API_KEY"]
+  NEXT_PUBLIC_FIREBASE_APP_ID                = var.netlify_env_vars["NEXT_PUBLIC_FIREBASE_APP_ID"]
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN           = var.netlify_env_vars["NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN"]
+  NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID        = var.netlify_env_vars["NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID"]
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID   = var.netlify_env_vars["NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID"]
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID            = var.netlify_env_vars["NEXT_PUBLIC_FIREBASE_PROJECT_ID"]
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET        = var.netlify_env_vars["NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET"]
+  NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI    = var.netlify_env_vars["NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI"]
+  NEXT_PUBLIC_FITBIT_CLIENT_ID               = var.netlify_env_vars["NEXT_PUBLIC_FITBIT_CLIENT_ID"]
+  NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI   = var.netlify_env_vars["NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI"]
+  NEXT_PUBLIC_RECAPTCHA_SITE_KEY             = var.netlify_env_vars["NEXT_PUBLIC_RECAPTCHA_SITE_KEY"]
 }
 
 module "ci" {
-  source          = "./10_ci"
-  input_variables = var.github_env_vars["ci"]["variables"]
-  input_secrets   = var.github_env_vars["ci"]["secrets"]
+  source = "./10_ci"
+
+  APP_ENVIRONMENT                          = var.github_env_vars["ci"]["variables"]["APP_ENVIRONMENT"]
+  FITBIT_BACKEND_REDIRECT_URI              = var.github_env_vars["ci"]["variables"]["FITBIT_BACKEND_REDIRECT_URI"]
+  FITBIT_REDIRECT_URI                      = var.github_env_vars["ci"]["variables"]["FITBIT_REDIRECT_URI"]
+  NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI  = var.github_env_vars["ci"]["variables"]["NEXT_PUBLIC_FITBIT_BACKEND_REDIRECT_URI"]
+  NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI = var.github_env_vars["ci"]["variables"]["NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI"]
+  NEXT_PUBLIC_MOCK_AUTH                    = var.github_env_vars["ci"]["variables"]["NEXT_PUBLIC_MOCK_AUTH"]
+
+  FITBIT_CLIENT_ID               = var.github_env_vars["ci"]["secrets"]["FITBIT_CLIENT_ID"]
+  FITBIT_CLIENT_SECRET           = var.github_env_vars["ci"]["secrets"]["FITBIT_CLIENT_SECRET"]
+  NEXT_PUBLIC_RECAPTCHA_SITE_KEY = var.github_env_vars["ci"]["secrets"]["NEXT_PUBLIC_RECAPTCHA_SITE_KEY"]
 }
 
 # module "preview" {
@@ -22,14 +45,30 @@ module "ci" {
 # }
 
 module "stg" {
-  source          = "./30_stg"
-  input_variables = var.github_env_vars["staging"]["variables"]
-  input_secrets   = var.github_env_vars["staging"]["secrets"]
+  source = "./30_stg"
+
+  FITBIT_REDIRECT_URI = var.github_env_vars["staging"]["variables"]["FITBIT_REDIRECT_URI"]
+
+  DISCORD_WEBHOOK_ID    = var.github_env_vars["staging"]["secrets"]["DISCORD_WEBHOOK_ID"]
+  DISCORD_WEBHOOK_TOKEN = var.github_env_vars["staging"]["secrets"]["DISCORD_WEBHOOK_TOKEN"]
+  FITBIT_CLIENT_ID      = var.github_env_vars["staging"]["secrets"]["FITBIT_CLIENT_ID"]
+  FITBIT_CLIENT_SECRET  = var.github_env_vars["staging"]["secrets"]["FITBIT_CLIENT_SECRET"]
+  FUNCTION_REGION       = var.github_env_vars["staging"]["secrets"]["FUNCTION_REGION"]
+  GCP_SA_KEY            = var.github_env_vars["staging"]["secrets"]["GCP_SA_KEY"]
+  PROJECT_ID            = var.github_env_vars["staging"]["secrets"]["PROJECT_ID"]
 }
 
 module "prod" {
-  source          = "./40_PROD"
-  input_variables = var.github_env_vars["production"]["variables"]
-  input_secrets   = var.github_env_vars["production"]["secrets"]
+  source = "./40_PROD"
+
+  FITBIT_REDIRECT_URI = var.github_env_vars["production"]["variables"]["FITBIT_REDIRECT_URI"]
+
+  DISCORD_WEBHOOK_ID    = var.github_env_vars["production"]["secrets"]["DISCORD_WEBHOOK_ID"]
+  DISCORD_WEBHOOK_TOKEN = var.github_env_vars["production"]["secrets"]["DISCORD_WEBHOOK_TOKEN"]
+  FITBIT_CLIENT_ID      = var.github_env_vars["production"]["secrets"]["FITBIT_CLIENT_ID"]
+  FITBIT_CLIENT_SECRET  = var.github_env_vars["production"]["secrets"]["FITBIT_CLIENT_SECRET"]
+  FUNCTION_REGION       = var.github_env_vars["production"]["secrets"]["FUNCTION_REGION"]
+  GCP_SA_KEY            = var.github_env_vars["production"]["secrets"]["GCP_SA_KEY"]
+  PROJECT_ID            = var.github_env_vars["production"]["secrets"]["PROJECT_ID"]
 }
 


### PR DESCRIPTION
## 変更内容
Terraformのモジュールへの変数渡しを、従来の「Map一括注入」から「各変数の明示的な定義と個別渡し」に変更しました。
これにより、各モジュール（CI, Staging, Production, Common）でどのような環境変数が必要かがコード上で明確になりました。
また、terraform.tfvars （Git管理外のシークレット）の構造は変更せず、main.tf での読み替えを行うことで、既存の値をそのまま利用できるようにしています。

## 検証
terraform plan -lock=false を実行し、変更差分がないこと（No changes）を確認済みです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

### チョア（Chores）
* インフラストラクチャの環境変数設定を再構成し、複数環境での管理を統一しました
* Firebase、Fitbit、Discord webhook、reCAPTCHA認証に関連する新しい環境変数を追加しました
* CI/CD、ステージング、本番環境における設定構造をより明確で保守しやすいものに改善しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->