### PR TITLE
fix(ci): fix coverage report deployment and remove playwright

### DIFF
--- a/.github/workflows/deploy-coverage.yaml
+++ b/.github/workflows/deploy-coverage.yaml
@@ -14,7 +14,7 @@ jobs:
       ENVIRONMENT: ci-test
       NEXT_PUBLIC_MOCK_AUTH: "true"
       NEXT_PUBLIC_FITBIT_CLIENT_ID: "mock-client-id"
-      NEXT_PUBLIC_RECAPTCHA_SITE_KEY: "mock-site-key"
+      NEXT_PUBLIC_RECAPTCHA_V3_SITE_KEY: "mock-site-key"
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -22,32 +22,20 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup
 
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-        with:
-          playwright-browsers-path: ${{ github.workspace }}/.cache/playwright
-
       - name: Build Shared
         run: pnpm --filter shared run build
 
       - name: Run Coverage
         run: pnpm -r run test:coverage
 
-      - name: Run E2E Tests
-        run: pnpm --filter frontend run test:e2e:ci
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/playwright
-
       - name: Prepare Coverage Report
         run: |
           mkdir -p _site/frontend
           mkdir -p _site/backend
           mkdir -p _site/shared
-          mkdir -p _site/frontend/playwright
           cp -r frontend/coverage/* _site/frontend/
           cp -r backend/coverage/* _site/backend/
           cp -r shared/coverage/* _site/shared/
-          cp -r frontend/test/results/playwright-report/* _site/frontend/playwright/
 
       - name: Create Index Page
         run: |
@@ -75,7 +63,6 @@ jobs:
                   <li><a href="./frontend/index.html">Frontend Coverage (Vitest)</a></li>
                   <li><a href="./backend/index.html">Backend Coverage (Vitest)</a></li>
                   <li><a href="./shared/index.html">Shared Coverage (Vitest)</a></li>
-                  <li><a href="./frontend/playwright/index.html">Frontend E2E (Playwright)</a></li>
               </ul>
               <div class="meta">
                   Last updated: $(date '+%Y-%m-%d %H:%M:%S') (Ref: ${GITHUB_SHA::7})

--- a/scripts/inject-dark-mode.js
+++ b/scripts/inject-dark-mode.js
@@ -15,11 +15,6 @@ function addDarkMode(dir) {
   for (const file of files) {
     const fullPath = path.join(dir, file);
 
-    // Skip Playwright reports
-    if (fullPath.includes("playwright")) {
-      continue;
-    }
-
     const stat = fs.statSync(fullPath);
 
     if (stat.isDirectory()) {


### PR DESCRIPTION
## Description
Fixes the environment variable name for Recaptcha V3 site key and removes Playwright from the deploy-coverage workflow to improve stability.

## Changes
- Renamed NEXT_PUBLIC_RECAPTCHA_SITE_KEY to NEXT_PUBLIC_RECAPTCHA_V3_SITE_KEY in .github/workflows/deploy-coverage.yaml.
- Removed Playwright setup and E2E test steps from .github/workflows/deploy-coverage.yaml.
- Removed Playwright exclusion logic from scripts/inject-dark-mode.js.

## Verification
- CI should pass with these changes.
