### PR TITLE
fix(backend): package.jsonのmainフィールドを削除

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Fitbit food logging logic for Gemini custom Gem.",
   "type": "module",
-  "main": "dist/index.js",
   "scripts": {
     "start": "functions-framework --target=healthChecker",
     "gcp-build": "node -e \"console.log('Skipping build on GCP')\"",


### PR DESCRIPTION
## 概要

PR #108 で backend/src/index.ts を削除した際、package.json の main フィールドが古いまま残っていたため、Cloud Functions デプロイ時に dist/index.js が存在しないエラーが発生しました。

## 問題

- backend/src/index.ts を削除
- tsup.config.ts のエントリーポイントから index.ts を除外
- しかし package.json の "main": "dist/index.js" が残っていた
- Cloud Functions が package.json の main を参照して dist/index.js を探すが存在しない

## 修正内容

package.json から main フィールドを削除しました。

各 Cloud Function は個別のエントリーポイント（healthChecker, recaptchaVerifier, oauthHandler, foodLogHandler）を持っており、デプロイ時に --entry-point オプションで明示的に指定されるため、main フィールドは不要です。

## 検証結果

- ✅ ビルド成功: dist/health.js, dist/recaptcha.js, dist/handlers/oauth.js, dist/handlers/foodlog.js が生成
- ✅ 全テスト成功: 77/77 tests passed

## 変更ファイル

- backend/package.json


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストは、内部的な設定調整を含んでいます。エンドユーザーに対する直接的な機能変更はありません。

* **Chores**
  * パッケージ設定の調整を実施しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->