### PR TITLE
feat: backendデプロイの最適化とビルド警告の解消

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -35,8 +35,10 @@ jobs:
           pnpm --filter backend deploy backend-deploy --prod
           # pnpm deploy might not copy 'dist' if it's ignored by git. Copy it manually.
           cp -r backend/dist backend-deploy/
-          # Copy .gcloudignore to ensure proper filtering during gcloud deploy
-          cp backend/.gcloudignore backend-deploy/
+          # Copy .gcloudignore if it exists to ensure proper filtering during gcloud deploy
+          if [ -f backend/.gcloudignore ]; then
+            cp backend/.gcloudignore backend-deploy/
+          fi
           # Remove node_modules to keep the artifact slim (GCP will reinstall based on lockfile)
           rm -rf backend-deploy/node_modules
 


### PR DESCRIPTION
## 概要

backendのデプロイ時に表示されていた「lockファイルが見つからない」というビルド警告を解消するため、`pnpm deploy`を導入しました。

## 変更内容

- `cd-backend.yaml`の`build`ジョブを修正
  - `pnpm deploy`を使用して、backendパッケージとその本番用依存関係のみを抽出したディレクトリを作成
  - backend固有の`pnpm-lock.yaml`が生成されるようになり、Google Cloud Buildの警告が解消されます
  - アーティファクトから`node_modules`を除外することで、アップロードサイズを軽量化（50MB以上削減される見込み）
  - 手動ビルドした`dist`フォルダと`.gcloudignore`を確実にデプロイ用ディレクトリに同梱

## 検証結果

- ワークフローのシンタックスチェック済み
- ブランチをプッシュし、プルリクエストを作成しました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * バックエンドのデプロイワークフローを見直しました。
  * パッケージマネージャー経由のデプロイに切替え、展開手順を簡素化。
  * ビルド済み出力やデプロイ時の除外設定を含めてアーティファクトを準備。
  * 不要な依存を除外してアーティファクトを軽量化。
  * アップロード対象を新しい配布用フォルダに変更。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->