### PR TITLE
fix: GCP Buildでのworkspaceプロトコル解決エラーを修正

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -39,8 +39,14 @@ jobs:
           if [ -f backend/.gcloudignore ]; then
             cp backend/.gcloudignore backend-deploy/
           fi
+          # Ensure devDependencies are removed to avoid "workspace:" protocol errors in npm-based environments
+          cd backend-deploy
+          npm pkg delete devDependencies
+          # Verification
+          echo "Final package.json content:"
+          cat package.json
           # Remove node_modules to keep the artifact slim (GCP will reinstall based on lockfile)
-          rm -rf backend-deploy/node_modules
+          rm -rf node_modules
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,10 @@
   "description": "Fitbit food logging logic for Gemini custom Gem.",
   "type": "module",
   "main": "dist/index.js",
+  "engines": {
+    "node": ">=20.0.0",
+    "pnpm": ">=9.0.0"
+  },
   "scripts": {
     "start": "functions-framework --target=healthChecker",
     "gcp-build": "node -e \"console.log('Skipping build on GCP')\"",


### PR DESCRIPTION
## 概要

前のPRで導入した`pnpm deploy`により、GCP Build側で`workspace:`プロトコルが含まれる`package.json`（devDependencies）が残ってしまい、npm環境で解析エラーが発生していた問題を修正しました。

## 修正内容

- `backend/package.json`に`engines.pnpm`を追加し、GCP Buildがpnpmを優先検出するように改善
- ワークフローのデプロイ準備ステップで、`pnpm deploy`後のパッケージから`devDependencies`を明示的に削除
- デプロイ用ディレクトリの中身と`package.json`をログに出力するデバッグ情報を追加

## 期待される効果

- GCP Buildが正常に完了し、デプロイが成功するようになります
