### PR TITLE
fix(backend): generate pnpm-lock.yaml in deploy artifact

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -32,21 +32,26 @@ jobs:
         # pnpm deploy creates a pruned directory with only production dependencies.
         # It also generates a dedicated pnpm-lock.yaml for this isolated package.
         run: |
-          pnpm --filter backend deploy backend-deploy --prod
+          pnpm --filter backend deploy backend-deploy --prod --legacy
           # pnpm deploy might not copy 'dist' if it's ignored by git. Copy it manually.
           cp -r backend/dist backend-deploy/
           # Copy .gcloudignore if it exists to ensure proper filtering during gcloud deploy
           if [ -f backend/.gcloudignore ]; then
             cp backend/.gcloudignore backend-deploy/
           fi
-          # Ensure devDependencies are removed to avoid "workspace:" protocol errors in npm-based environments
+          # IMPORTANT: Generate a standalone pnpm-lock.yaml for GCP Buildpacks to detect pnpm.
+          # pnpm deploy doesn't always provide a lockfile in the destination.
           cd backend-deploy
+          pnpm install --lockfile-only
+          # Ensure devDependencies are removed to avoid "workspace:" protocol errors in npm-based environments
           npm pkg delete devDependencies
-          # Verification
-          echo "Final package.json content:"
-          cat package.json
           # Remove node_modules to keep the artifact slim (GCP will reinstall based on lockfile)
           rm -rf node_modules
+          # Verification and Debugging
+          echo "Final package.json content:"
+          cat package.json
+          echo "Files in deployment directory (pnpm-lock.yaml MUST be here):"
+          ls -F
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概要

Google Cloud Functions (Gen2) のビルドプロセスにおいて、`pnpm` が正しく使用されず `npm` にフォールバックしてしまう問題（およびそれに伴うビルド警告・エラー）を修正します。

## 変更内容

1.  **pnpm-lock.yaml の強制生成**:
    - `Prepare Deployment Directory` ステップにおいて、`pnpm deploy` 実行後にそのディレクトリ内で `pnpm install --lockfile-only` を実行するように追加しました。
    - これにより、GCP Buildpacks が `pnpm-lock.yaml` を検知し、`pnpm` をパッケージマネージャーとして採用するようになります。

2.  **pnpm v10 互換性の確保**:
    - `pnpm deploy` コマンドに `--legacy` フラグを追加しました。
    - pnpm v10 以降の挙動において、workspace 設定の扱いに起因するエラーや意図しない挙動を防ぐための措置です。

## 解決する課題

- **ビルド警告の解消**: "Improve build performance by generating and committing package-lock.json" という警告が消え、正しく `pnpm install` が行われるようになります。
- **依存関係解決エラーの防止**: `npm` が誤って使用されることによる `workspace:` プロトコル解釈エラーを根本から防ぎます。

## 検証結果

- ローカル環境（`.agent/tmp/`）での隔離検証により、本修正手順で **backend 単体に限定されたクリーンな `pnpm-lock.yaml`** が生成されることを確認済みです。
- 生成されたロックファイルには `functions-framework`, `firebase-admin` 等の必要な依存関係のみが含まれます。

## レビュー依頼

@coderabbitai review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Node.js 20以上およびpnpm 9以上が必須となりました
  * 検証ライブラリを追加しました
  * デプロイメントワークフローを最適化し、変更内容に基づいた選別デプロイを実現しました
  * 環境ベースのクラウド設定初期化に対応しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->