### PR TITLE
fix(ci): fix workspace protocol error in pnpm install

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -42,9 +42,9 @@ jobs:
           # IMPORTANT: Generate a standalone pnpm-lock.yaml for GCP Buildpacks to detect pnpm.
           # pnpm deploy doesn't always provide a lockfile in the destination.
           cd backend-deploy
-          pnpm install --lockfile-only --no-frozen-lockfile --ignore-workspace
-          # Ensure devDependencies are removed to avoid "workspace:" protocol errors in npm-based environments
+          # Ensure devDependencies are removed BEFORE install to avoid "workspace:" protocol errors in pnpm v10
           npm pkg delete devDependencies
+          pnpm install --lockfile-only --no-frozen-lockfile --ignore-workspace
           # Remove node_modules to keep the artifact slim (GCP will reinstall based on lockfile)
           rm -rf node_modules
           # Verification and Debugging


### PR DESCRIPTION
## 概要

pnpm v10 での `pnpm install --ignore-workspace` 実行時に `workspace:*` プロトコル解決エラーが発生する問題を修正しました。

## 原因

`pnpm deploy` 後も `devDependencies` に `workspace:*` 依存が残っており、インストール時に解決できずエラーとなっていました。

## 修正内容

`cd-backend.yaml` において、`npm pkg delete devDependencies` の実行順序を `pnpm install` の前に移動しました。
