### PR TITLE
fix(ci): clear node_modules before lockfile regen to incorrect workspace resolution

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -50,6 +50,10 @@ jobs:
           # We must DELETE it to force pnpm to generate a clean, standalone lockfile based on the pruned package.json.
           rm -f pnpm-lock.yaml
 
+          # ALSO CRITICAL: Remove the node_modules created by 'pnpm deploy' as it contains the symlinks triggering the error.
+          # We want a fresh install based strictly on the pruned package.json.
+          rm -rf node_modules
+
           # Re-generate a clean lockfile for the production dependencies
           pnpm install --lockfile-only --no-frozen-lockfile --ignore-workspace
           # Remove node_modules to keep the artifact slim (GCP will reinstall based on lockfile)


### PR DESCRIPTION
# pnpm lockfile 生成フローの修正 (node_modules クリーンアップ追加)

## 変更の目的

PR #121 での修正後も GCP ビルドエラー (`ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY Broken lockfile`) が解決しなかった問題に対処します。
調査の結果、`pnpm install --lockfile-only` が、直前の `pnpm deploy` で生成された `node_modules` 内のシンボリックリンク（ワークスペース参照）を誤って拾い、隔離環境では無効な `file:shared` 参照を含むロックファイルを生成していたことが判明しました。

## 変更内容

- `.github/workflows/cd-backend.yaml`:
  - デプロイ用アーティファクト作成ステップにおいて、ロックファイルを再生成する**直前**に `rm -rf node_modules` を追加しました。
  - これにより、`pnpm install` はクリーンな状態で、整理済みの `package.json` のみに基づいて依存関係を解決するようになり、正しいスタンドアロンなロックファイルが生成されます。

## 検証結果 (ローカル再現実験)

ローカル環境にて以下の手順で検証を行い、修正の有効性を確認しました。

1.  **失敗ケース（修正なし）**:
    - `node_modules` を残したままロックファイルを生成 -> `pnpm-lock.yaml` に `file:shared` が含まれることを確認（**NG**）。
2.  **成功ケース（本修正）**:
    - `rm -rf node_modules` を実行後にロックファイルを生成 -> `pnpm-lock.yaml` から `file:shared` が消滅することを確認（**OK**）。

## 関連

- Previous PR: #121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDパイプラインの依存関係インストール処理を改善し、より確実なクリーンアップ手順を追加しました。これにより、デプロイメントプロセスがより堅牢になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->