### PR TITLE
fix(ci): optimize backend deployment with NODE_ENV=production

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -146,7 +146,8 @@ jobs:
             --entry-point=healthChecker \
             --trigger-http \
             --allow-unauthenticated \
-            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }}" \
+            --set-build-env-vars=NODE_ENV=production \
+            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},NODE_ENV=production" \
             --project=${{ secrets.PROJECT_ID }}
 
       - name: Define Context
@@ -202,7 +203,8 @@ jobs:
             --entry-point=recaptchaVerifier \
             --trigger-http \
             --allow-unauthenticated \
-            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }}" \
+            --set-build-env-vars=NODE_ENV=production \
+            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},NODE_ENV=production" \
             --project=${{ secrets.PROJECT_ID }}
 
       - name: Define Context
@@ -258,7 +260,8 @@ jobs:
             --entry-point=oauthHandler \
             --trigger-http \
             --allow-unauthenticated \
-            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},OAUTH_FITBIT_REDIRECT_URI=${{ vars.OAUTH_FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},ALLOWED_REDIRECT_ORIGINS=${{ vars.ALLOWED_REDIRECT_ORIGINS }},ALLOWED_REDIRECT_PATTERN=${{ vars.ALLOWED_REDIRECT_PATTERN }}" \
+            --set-build-env-vars=NODE_ENV=production \
+            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},OAUTH_FITBIT_REDIRECT_URI=${{ vars.OAUTH_FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},ALLOWED_REDIRECT_ORIGINS=${{ vars.ALLOWED_REDIRECT_ORIGINS }},ALLOWED_REDIRECT_PATTERN=${{ vars.ALLOWED_REDIRECT_PATTERN }},NODE_ENV=production" \
             --project=${{ secrets.PROJECT_ID }}
 
       - name: Define Context
@@ -314,7 +317,8 @@ jobs:
             --entry-point=foodLogHandler \
             --trigger-http \
             --allow-unauthenticated \
-            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},OAUTH_FITBIT_REDIRECT_URI=${{ vars.OAUTH_FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }}" \
+            --set-build-env-vars=NODE_ENV=production \
+            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},OAUTH_FITBIT_REDIRECT_URI=${{ vars.OAUTH_FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},NODE_ENV=production" \
             --project=${{ secrets.PROJECT_ID }}
 
       - name: Define Context


### PR DESCRIPTION
# fix(ci): バックエンド本番環境の最適化（NODE_ENV=production）

バックエンドのデプロイ環境を `production` に最適化し、性能・セキュリティ・一貫性を向上させます。

## 変更内容

### [cd-backend.yaml](.github/workflows/cd-backend.yaml)

以下の4つの関数すべてにおいて、ビルド時および実行時の環境変数を `production` に設定しました：

- `healthChecker`
- `recaptchaVerifier`
- `oauthHandler`
- `foodLogHandler`

**変更詳細:**

- デプロイコマンドに `--set-build-env-vars=NODE_ENV=production` を追加
- 実行時の `--set-env-vars` に `NODE_ENV=production` を追加

## 解決される問題とメリット

1.  **パフォーマンス向上**:
    Express や Firebase SDK などのライブラリが `production` モードの最適化ロジック（キャッシュの有効化、デバッグ用チェックの無効化など）を適用します。これにより、レスポンス速度の向上が期待できます。
2.  **セキュリティ向上**:
    エラー発生時に詳細なスタックトレースがエンドユーザーに露出するリスクを低減します。
3.  **ログの整理**:
    GCP Buildpacks が `development` モードとして実行される際に発生していた不要な警告や通知が抑制され、ビルドログがクリーンになります。
4.  **環境の整合性**:
    アーティテクトは既に Production 用に構成されているため、システム全体のモードを一致させることで予期せぬ挙動を防ぎます。

## 検証結果

- `develop` ブランチでのビルド成功を確認後、GCP Cloud Build のログで `Running "pnpm install (CI=true NODE_ENV=production)"` と表示されることを確認します。
