### PR TITLE
fix(ci): add environment to build-base-image for secret access

### DIFF
--- a/.github/workflows/build-base-image.yaml
+++ b/.github/workflows/build-base-image.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Fixes CI failure by allowing build-base-image workflow to access environment secrets (GCP_SA_KEY).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * ビルドプロセスにおいて、ブランチに応じた環境の自動設定機能を追加しました。メインブランチではプロダクション環境、その他のブランチではステージング環境が自動で設定されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->