### PR TITLE
fix(ci): use standard Dockerfile name for gcloud compatibility

### DIFF
--- a/.github/workflows/build-base-image.yaml
+++ b/.github/workflows/build-base-image.yaml
@@ -42,7 +42,7 @@ jobs:
           # backend パッケージをコピー
           mkdir -p base-context/backend
           cp backend/package.json base-context/backend/
-          cp backend/Dockerfile.base base-context/ # Ensure Dockerfile.base is copied to context root
+          cp backend/Dockerfile.base base-context/Dockerfile # Rename to Dockerfile for gcloud builds submit
 
           # shared パッケージをコピー
           mkdir -p base-context/shared
@@ -63,7 +63,6 @@ jobs:
           gcloud builds submit \
             --project=${{ secrets.PROJECT_ID }} \
             --tag=asia-northeast1-docker.pkg.dev/${{ secrets.PROJECT_ID }}/gcf-artifacts/backend-base:latest \
-            --file=Dockerfile.base \
             .
 
       - name: Tag with Git SHA


### PR DESCRIPTION
Renames Dockerfile.base to Dockerfile in the build context because 'gcloud builds submit' does not support custom filenames without cloudbuild.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ベースイメージのビルドワークフローを更新しました。Dockerfileの指定方法を変更し、ビルドコンテキストの構成を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->