### PR TITLE
fix(ci): switch to native docker build to bypass logging error

### DIFF
--- a/.github/workflows/build-base-image.yaml
+++ b/.github/workflows/build-base-image.yaml
@@ -57,13 +57,16 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Configure Docker
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
+
       - name: Build and Push Base Image
         run: |
           cd base-context
-          gcloud builds submit \
-            --project=${{ secrets.PROJECT_ID }} \
-            --tag=asia-northeast1-docker.pkg.dev/${{ secrets.PROJECT_ID }}/gcf-artifacts/backend-base:latest \
+          docker build \
+            --tag asia-northeast1-docker.pkg.dev/${{ secrets.PROJECT_ID }}/gcf-artifacts/backend-base:latest \
             .
+          docker push asia-northeast1-docker.pkg.dev/${{ secrets.PROJECT_ID }}/gcf-artifacts/backend-base:latest
 
       - name: Tag with Git SHA
         run: |


### PR DESCRIPTION
Replaces 'gcloud builds submit' with 'docker build + push' on GitHub Runner. This avoids the permissions error 'This tool can only stream logs if you are Viewer/Owner' while still successfully building and pushing the image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
  * ビルドプロセスの認証フローを改善し、ビルドメソッドを最適化しました。基盤イメージのタグ付けおよびデプロイメント処理に変更はありません。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->