### PR TITLE
fix(cd): enable Dockerfile build by removing runtime flag

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -151,7 +151,6 @@ jobs:
           gcloud functions deploy healthchecker \
             --gen2 \
             --region=${{ secrets.FUNCTION_REGION }} \
-            --runtime=nodejs20 \
             --source=backend \
             --entry-point=healthChecker \
             --trigger-http \
@@ -212,7 +211,6 @@ jobs:
           gcloud functions deploy recaptchaverifier \
             --gen2 \
             --region=${{ secrets.FUNCTION_REGION }} \
-            --runtime=nodejs20 \
             --source=backend \
             --entry-point=recaptchaVerifier \
             --trigger-http \
@@ -273,7 +271,6 @@ jobs:
           gcloud functions deploy oauthhandler \
             --gen2 \
             --region=${{ secrets.FUNCTION_REGION }} \
-            --runtime=nodejs20 \
             --source=backend \
             --entry-point=oauthHandler \
             --trigger-http \
@@ -334,7 +331,6 @@ jobs:
           gcloud functions deploy foodloghandler \
             --gen2 \
             --region=${{ secrets.FUNCTION_REGION }} \
-            --runtime=nodejs20 \
             --source=backend \
             --entry-point=foodLogHandler \
             --trigger-http \


### PR DESCRIPTION
Removes '--runtime=nodejs20' from 'gcloud functions deploy' commands. This instructs Cloud Functions Gen 2 to use the provided Dockerfile for building the container, bypassing the standard buildpack which fails on 'workspace:*' dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * バックエンド展開設定を最適化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->