### PR TITLE
fix(ci): implement image-based deployment

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -80,6 +80,11 @@ jobs:
     secrets: inherit
 
   build:
+    needs: [filter_changes, build_base]
+    if: |
+      always() && 
+      !contains(needs.*.result, 'failure') && 
+      !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     permissions:


### PR DESCRIPTION
Switches deployment strategy from source upload to pre-built Docker image. This resolves the 'workspace:*' error in Cloud Functions buildpacks by performing the build entirely within GitHub Actions (using 'docker build') and deploying the resulting image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

このリリースには、エンドユーザーに影響する変更はありません。

**内容:** 内部インフラストラクチャ（CI/CDワークフロー）の最適化のみが含まれています。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->