### PR TITLE
fix(cd): migrate to gcloud run deploy

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -154,9 +154,11 @@ jobs:
           gcloud run deploy healthchecker \
             --region=${{ secrets.FUNCTION_REGION }} \
             --image=${{ needs.build.outputs.image_uri }} \
+            --port=8080 \
+            --memory=256Mi \
+            --max-instances=100 \
             --allow-unauthenticated \
-
-            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},NODE_ENV=production,FUNCTION_TARGET=healthChecker" \
+            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},NODE_ENV=production,FUNCTION_TARGET=healthChecker,LOG_EXECUTION_ID=true" \
             --project=${{ secrets.PROJECT_ID }}
 
       - name: Define Context
@@ -206,9 +208,11 @@ jobs:
           gcloud run deploy recaptchaverifier \
             --region=${{ secrets.FUNCTION_REGION }} \
             --image=${{ needs.build.outputs.image_uri }} \
+            --port=8080 \
+            --memory=256Mi \
+            --max-instances=100 \
             --allow-unauthenticated \
-
-            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},NODE_ENV=production,FUNCTION_TARGET=recaptchaVerifier" \
+            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},NODE_ENV=production,FUNCTION_TARGET=recaptchaVerifier,LOG_EXECUTION_ID=true" \
             --project=${{ secrets.PROJECT_ID }}
 
       - name: Define Context
@@ -258,9 +262,11 @@ jobs:
           gcloud run deploy oauthhandler \
             --region=${{ secrets.FUNCTION_REGION }} \
             --image=${{ needs.build.outputs.image_uri }} \
+            --port=8080 \
+            --memory=256Mi \
+            --max-instances=100 \
             --allow-unauthenticated \
-
-            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},OAUTH_FITBIT_REDIRECT_URI=${{ vars.OAUTH_FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},ALLOWED_REDIRECT_ORIGINS=${{ vars.ALLOWED_REDIRECT_ORIGINS }},ALLOWED_REDIRECT_PATTERN=${{ vars.ALLOWED_REDIRECT_PATTERN }},NODE_ENV=production,FUNCTION_TARGET=oauthHandler" \
+            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},OAUTH_FITBIT_REDIRECT_URI=${{ vars.OAUTH_FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},ALLOWED_REDIRECT_ORIGINS=${{ vars.ALLOWED_REDIRECT_ORIGINS }},ALLOWED_REDIRECT_PATTERN=${{ vars.ALLOWED_REDIRECT_PATTERN }},NODE_ENV=production,FUNCTION_TARGET=oauthHandler,LOG_EXECUTION_ID=true" \
             --project=${{ secrets.PROJECT_ID }}
 
       - name: Define Context
@@ -310,9 +316,11 @@ jobs:
           gcloud run deploy foodloghandler \
             --region=${{ secrets.FUNCTION_REGION }} \
             --image=${{ needs.build.outputs.image_uri }} \
+            --port=8080 \
+            --memory=256Mi \
+            --max-instances=100 \
             --allow-unauthenticated \
-
-            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},OAUTH_FITBIT_REDIRECT_URI=${{ vars.OAUTH_FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},NODE_ENV=production,FUNCTION_TARGET=foodLogHandler" \
+            --set-env-vars="GCP_PROJECT=${{ secrets.PROJECT_ID }},FITBIT_REDIRECT_URI=${{ vars.FITBIT_REDIRECT_URI }},OAUTH_FITBIT_REDIRECT_URI=${{ vars.OAUTH_FITBIT_REDIRECT_URI }},FUNCTION_REGION=${{ secrets.FUNCTION_REGION }},FITBIT_CLIENT_ID=${{ secrets.FITBIT_CLIENT_ID }},FITBIT_CLIENT_SECRET=${{ secrets.FITBIT_CLIENT_SECRET }},RECAPTCHA_V3_SECRET_KEY=${{ secrets.RECAPTCHA_V3_SECRET_KEY }},NODE_ENV=production,FUNCTION_TARGET=foodLogHandler,LOG_EXECUTION_ID=true" \
             --project=${{ secrets.PROJECT_ID }}
 
       - name: Define Context


### PR DESCRIPTION
Switch from 'gcloud functions deploy' to 'gcloud run deploy' in cd-backend.yaml. Cloud Functions Gen 2 deploy command does not support --image flag. Cloud Run deploy does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **チア**
  * バックエンド基盤を Cloud Run ベースに移行し、信頼性とスケーラビリティを向上しました。
* **Chores**
  * 一部バックエンドサービスの実行環境を調整し、メモリ／同時実行制限等で安定性を強化しました。
  * 実行ログの識別を有効化し、トラブルシューティングと監視性を改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->