### PR TITLE
fix(cd): bypass secret masking for image URI

### DIFF
--- a/.github/workflows/cd-backend.yaml
+++ b/.github/workflows/cd-backend.yaml
@@ -90,8 +90,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    outputs:
-      image_uri: ${{ steps.build-image.outputs.image_uri }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -128,7 +127,7 @@ jobs:
             backend
 
           docker push "${IMAGE_URI}"
-          echo "image_uri=${IMAGE_URI}" >> $GITHUB_OUTPUT
+          docker push "${IMAGE_URI}"
 
   deploy_health:
     needs: [build, filter_changes, build_base]
@@ -153,7 +152,7 @@ jobs:
         run: |
           gcloud run deploy healthchecker \
             --region=${{ secrets.FUNCTION_REGION }} \
-            --image=${{ needs.build.outputs.image_uri }} \
+            --image=asia-northeast1-docker.pkg.dev/${{ secrets.PROJECT_ID }}/gcf-artifacts/backend-app:${{ github.sha }} \
             --port=8080 \
             --memory=256Mi \
             --max-instances=100 \
@@ -207,7 +206,7 @@ jobs:
         run: |
           gcloud run deploy recaptchaverifier \
             --region=${{ secrets.FUNCTION_REGION }} \
-            --image=${{ needs.build.outputs.image_uri }} \
+            --image=asia-northeast1-docker.pkg.dev/${{ secrets.PROJECT_ID }}/gcf-artifacts/backend-app:${{ github.sha }} \
             --port=8080 \
             --memory=256Mi \
             --max-instances=100 \
@@ -261,7 +260,7 @@ jobs:
         run: |
           gcloud run deploy oauthhandler \
             --region=${{ secrets.FUNCTION_REGION }} \
-            --image=${{ needs.build.outputs.image_uri }} \
+            --image=asia-northeast1-docker.pkg.dev/${{ secrets.PROJECT_ID }}/gcf-artifacts/backend-app:${{ github.sha }} \
             --port=8080 \
             --memory=256Mi \
             --max-instances=100 \
@@ -315,7 +314,7 @@ jobs:
         run: |
           gcloud run deploy foodloghandler \
             --region=${{ secrets.FUNCTION_REGION }} \
-            --image=${{ needs.build.outputs.image_uri }} \
+            --image=asia-northeast1-docker.pkg.dev/${{ secrets.PROJECT_ID }}/gcf-artifacts/backend-app:${{ github.sha }} \
             --port=8080 \
             --memory=256Mi \
             --max-instances=100 \


### PR DESCRIPTION
GitHub Actions blocked the image_uri output because it contained a secret (PROJECT_ID). This PR constructs the URI directly in the deploy jobs using the secret and github.sha.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * デプロイメントワークフローを最適化: ビルド出力の処理方法を改善し、コンテナイメージ参照の配信プロセスを簡素化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->