### PR TITLE
fix: remove redundant push trigger from base image build workflow

### DIFF
--- a/.github/workflows/build-base-image.yaml
+++ b/.github/workflows/build-base-image.yaml
@@ -3,12 +3,6 @@ name: Build Backend Base Image
 on:
   workflow_dispatch:
   workflow_call:
-  push:
-    branches: [main, develop]
-    paths:
-      - "backend/package.json"
-      - "backend/Dockerfile.base"
-      - "shared/**"
 
 jobs:
   build:


### PR DESCRIPTION
Removes the redundant 'push' trigger from build-base-image.yaml. This workflow should only be triggered via workflow_call from cd-backend.yaml or manually to prevent race conditions and authentication errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **Chores**
  * ビルドワークフローの自動実行トリガーを変更しました。ワークフローは手動トリガーと他のワークフロー呼び出しを通じてのみ実行されるようになります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->