### PR TITLE
feat: og画像の絶対パス化のためmetadataBaseを追加

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -18,18 +18,39 @@ const OG_IMAGE = "/images/1-photo-analysis.webp";
 
 /**
  * 環境変数からベースURLを取得する
- * NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI から /oauth を削除してベースURLを抽出
+ * Netlifyの組み込み環境変数 URL を使用し、未定義の場合はローカルホストにフォールバック
+ * @see https://docs.netlify.com/configure-builds/environment-variables/#read-only-variables
  */
 const getBaseUrl = (): string => {
-  const redirectUri = process.env.NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI;
-  if (redirectUri) {
-    return redirectUri.replace(/\/oauth$/, "");
+  // Netlifyの環境変数 URL は、デプロイコンテキストに応じて適切なベースURLを返す
+  // Production、Staging、Deploy Preview環境で自動設定される
+  // CI/ローカル環境では未定義のためフォールバックを使用
+  const siteUrl = process.env.URL;
+  if (siteUrl) {
+    try {
+      // URLの妥当性を検証
+      new URL(siteUrl);
+      return siteUrl;
+    } catch (error) {
+      console.error("Invalid site URL:", siteUrl, error);
+    }
   }
+
+  // フォールバック: ローカル開発環境およびCI環境
   return "http://localhost:3000";
 };
 
+// metadataBase の構築をエラーハンドリング付きで実行
+let metadataBase: URL;
+try {
+  metadataBase = new URL(getBaseUrl());
+} catch (error) {
+  console.error("Failed to create metadataBase URL:", error);
+  metadataBase = new URL("http://localhost:3000");
+}
+
 export const metadata = {
-  metadataBase: new URL(getBaseUrl()),
+  metadataBase,
   title: SITE_TITLE,
   description: SITE_DESCRIPTION,
   openGraph: {


### PR DESCRIPTION
## 変更内容

OG画像（Open Graph Protocol）の絶対パス化を実現するため、`metadataBase` を追加しました。

### 実装内容
- **`getBaseUrl()` 関数を追加**
  - 既存の環境変数 `NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI` から `/oauth` を削除してベースURLを抽出
  - ローカル環境では `http://localhost:3000` をフォールバック
- **`metadataBase` を設定**
  - Next.jsのメタデータに `metadataBase` を追加し、OG画像のURLを絶対パスに変換

### 背景
SNS（X/Twitter、Facebookなど）でシェアされた際、OG画像は絶対パスが推奨されています。相対パスのままだと一部のSNSで画像が正しく表示されない可能性があります。

### 技術的な選択
既存の環境変数を活用することで、新しい環境変数を追加せずに実装しました。Netlifyの各環境（Production、Staging、Deploy Preview）で動的に設定される `NEXT_PUBLIC_FITBIT_FRONTEND_REDIRECT_URI` を利用しています。

## テスト
-  TypeScriptコンパイルチェック: エラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * サイトメタデータにベースURLを追加・検証する仕組みを導入し、無効な値は安全に既定値へフォールバックします。
  * この対応により、SNS共有や外部参照時のメタデータ表示精度と堅牢性が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->