### PR TITLE
fix: deploy-coverageワークフローのトリガー条件を最適化

### DIFF
--- a/.github/workflows/deploy-coverage.yaml
+++ b/.github/workflows/deploy-coverage.yaml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - develop
+    paths:
+      - "frontend/**"
+      - "backend/**"
+      - "shared/**"
+      - "scripts/**"
+      - ".github/workflows/deploy-coverage.yaml"
 
 jobs:
   deploy-coverage:


### PR DESCRIPTION
## 変更内容
deploy-coverage.yaml に paths フィルターを追加し、関連ファイル（frontend, backend, shared, scripts, ワークフロー定義自体）に変更がない場合は実行されないようにしました。

## 目的
develop ブランチへの Force Push（Reset Model による履歴同期）時に、コードの実質的な変更がないにもかかわらずカバレッジデプロイが走ってしまう問題を解決するため。

## 確認事項
- [ ] 指定したパス以外の変更（例: READMEのみ、ドキュメントのみなど）ではワークフローがトリガーされないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 自動デプロイメントワークフローのトリガー条件を拡張しました。develop ブランチへのプッシュ時に、フロントエンド、バックエンド、共有リソース、スクリプトなどの変更に対してワークフローが自動実行されるようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->