### PR TITLE
fix: trigger deployment on pnpm overrides and global dependency changes

### DIFF
--- a/scripts/backend-filter.js
+++ b/scripts/backend-filter.js
@@ -235,22 +235,17 @@ function main() {
   // package.json, pnpm-lock.yaml, pnpm-workspace.yaml の変更は全関数に影響するため、即デプロイ
   for (const globalFile of GLOBAL_DEPENDENCIES) {
     if (changedFiles.includes(globalFile)) {
-      // package.json の場合は version のみの変更かどうかチェック
-      if (globalFile.endsWith("package.json")) {
-        if (!isPackageJsonVersionOnly(globalFile)) {
-          console.error(`  ✓ Global dependency changed: ${globalFile}`);
-          console.log("true");
-          return;
-        } else {
-          console.error(
-            `  Ignoring version-only change in global ${globalFile}`,
-          );
-        }
-      } else {
-        console.error(`  ✓ Global dependency changed: ${globalFile}`);
-        console.log("true");
-        return;
+      if (
+        globalFile.endsWith("package.json") &&
+        isPackageJsonVersionOnly(globalFile)
+      ) {
+        console.error(`  Ignoring version-only change in global ${globalFile}`);
+        continue;
       }
+
+      console.error(`  ✓ Global dependency changed: ${globalFile}`);
+      console.log("true");
+      return;
     }
   }
 

--- a/scripts/backend-filter.js
+++ b/scripts/backend-filter.js
@@ -57,6 +57,13 @@ const FUNCTION_DEPENDENCIES = {
   },
 };
 
+// 全ての関数に影響するグローバルな依存ファイル
+const GLOBAL_DEPENDENCIES = [
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+];
+
 // 無視するファイル
 const IGNORED_FILES = [/^backend\/test\//, /^shared\/test\//, /\.md$/];
 
@@ -125,6 +132,7 @@ function isPackageJsonVersionOnly(filePath) {
       "exports",
       "workspaces",
       "files",
+      "pnpm", // pnpm specific config like overrides
     ];
 
     for (const field of importantFields) {
@@ -221,6 +229,29 @@ function main() {
   if (changedFiles.length === 0) {
     console.log("false");
     return;
+  }
+
+  // 1. Check Global Dependencies first
+  // package.json, pnpm-lock.yaml, pnpm-workspace.yaml の変更は全関数に影響するため、即デプロイ
+  for (const globalFile of GLOBAL_DEPENDENCIES) {
+    if (changedFiles.includes(globalFile)) {
+      // package.json の場合は version のみの変更かどうかチェック
+      if (globalFile.endsWith("package.json")) {
+        if (!isPackageJsonVersionOnly(globalFile)) {
+          console.error(`  ✓ Global dependency changed: ${globalFile}`);
+          console.log("true");
+          return;
+        } else {
+          console.error(
+            `  Ignoring version-only change in global ${globalFile}`,
+          );
+        }
+      } else {
+        console.error(`  ✓ Global dependency changed: ${globalFile}`);
+        console.log("true");
+        return;
+      }
+    }
   }
 
   // 0. Pre-filter package.json files (backend/shared)

--- a/scripts/netlify-ignore.js
+++ b/scripts/netlify-ignore.js
@@ -171,6 +171,7 @@ async function isPackageJsonVersionOnly(filePath, githubContext) {
       "scripts",
       "engines",
       "workspaces",
+      "pnpm", // pnpm specific config like overrides
     ];
     for (const field of importantFields) {
       if (


### PR DESCRIPTION
## 変更内容

BackendとFrontendのデプロイ検知ロジック (`scripts/backend-filter.js`, `scripts/netlify-ignore.js`) を修正しました。

1. **共通:** `package.json` の `pnpm` フィールド（`overrides` 等）の変更を検知対象に追加。
2. **Backend:** `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml` の変更を「グローバル依存」として即デプロイ対象に追加。

これにより、依存関係のオーバーライドやロックファイルの更新によるビルド漏れを防ぎます。
