### PR TITLE
🛡️ Sentinel: [セキュリティ改善] firebase-admin の更新

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@google-cloud/functions-framework": "^3.0.0",
     "@smart-food-logger/shared": "workspace:*",
-    "firebase-admin": "^13.6.0",
+    "firebase-admin": "^13.6.1",
     "node-fetch": "^3.3.2",
     "zod": "^4.1.13"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       firebase-admin:
-        specifier: ^13.6.0
-        version: 13.6.0
+        specifier: ^13.6.1
+        version: 13.6.1
       node-fetch:
         specifier: ^3.3.2
         version: 3.3.2
@@ -3219,8 +3219,8 @@ packages:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
 
-  firebase-admin@13.6.0:
-    resolution: {integrity: sha512-GdPA/t0+Cq8p1JnjFRBmxRxAGvF/kl2yfdhALl38PrRp325YxyQ5aNaHui0XmaKcKiGRFIJ/EgBNWFoDP0onjw==}
+  firebase-admin@13.6.1:
+    resolution: {integrity: sha512-Zgc6yPtmPxAZo+FoK6LMG6zpSEsoSK8ifIR+IqF4oWuC3uWZU40OjxgfLTSFcsRlj/k/wD66zNv2UiTRreCNSw==}
     engines: {node: '>=18'}
 
   firebase@12.6.0:
@@ -7252,7 +7252,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7323,7 +7323,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.14(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(@vitest/ui@4.0.14)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -8532,7 +8532,7 @@ snapshots:
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
 
-  firebase-admin@13.6.0:
+  firebase-admin@13.6.1:
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0


### PR DESCRIPTION
Sentinelによるセキュリティメンテナンスです。

### 変更内容
- `backend` ワークスペースの `firebase-admin` を最新バージョン (`13.6.1`) に更新しました。

### 脆弱性 `fast-xml-parser` (GHSA-37qj-frw5-hhjh) について
- `firebase-admin` が依存する `@google-cloud/storage` 経由で `fast-xml-parser` の脆弱性 (High) が検出されています。
- 修正バージョンは `5.3.4` 以上ですが、これはメジャーバージョンアップであり、v4 系には修正パッチが存在しません。
- アプリケーションのコードベースを調査した結果、`backend` では `admin.firestore()` と `admin.auth()` のみを使用しており、**`admin.storage()` は使用していません**。
- したがって、XML パース処理が行われることはなく、この脆弱性が悪用されるリスクは極めて低いと判断しました。
- `pnpm.overrides` による v5 強制アップデートは、潜在的なランタイムエラー（破壊的変更）のリスクがあるため、今回は採用せず、`firebase-admin` の通常の更新のみを行いました。

### 検証
- `pnpm test` (backend/frontend) が全てパスすることを確認しました。

---
*PR created automatically by Jules for task [16718676814455215552](https://jules.google.com/task/16718676814455215552) started by @viv-devel*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他 (Chores)**
  * バックエンド依存関係を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->