### PR TITLE
🛡️ Sentinel: バックエンドのエラー詳細隠蔽による情報漏洩対策

### DIFF
--- a/backend/src/handlers/foodlog.ts
+++ b/backend/src/handlers/foodlog.ts
@@ -12,6 +12,7 @@ import {
 import {
   AuthenticationError,
   FitbitApiError,
+  handleError,
   MethodNotAllowedError,
   ValidationError,
 } from "../utils/errors.js";
@@ -134,20 +135,7 @@ export const foodLogHandler: HttpFunction = async (req, res) => {
 
     throw new MethodNotAllowedError("Method Not Allowed");
   } catch (error: any) {
-    console.error("Unhandled error in foodLogHandler:", error);
-    if (error.statusCode) {
-      res.status(error.statusCode).json({ error: error.message });
-      return;
-    } else if (
-      error.message.includes("ID token") ||
-      error.message.includes("Unauthorized")
-    ) {
-      res.status(401).json({ error: error.message });
-      return;
-    }
-    res
-      .status(500)
-      .json({ error: error.message || "An internal server error occurred." });
+    handleError(res, error);
     return;
   }
 };

--- a/backend/src/handlers/oauth.ts
+++ b/backend/src/handlers/oauth.ts
@@ -2,7 +2,11 @@ import { HttpFunction } from "@google-cloud/functions-framework";
 import { Buffer } from "buffer";
 
 import { exchangeCodeForTokens } from "../services/fitbitService.js";
-import { MethodNotAllowedError, ValidationError } from "../utils/errors.js";
+import {
+  handleError,
+  MethodNotAllowedError,
+  ValidationError,
+} from "../utils/errors.js";
 
 /**
  * リダイレクトURIが許可リストに含まれているか検証する
@@ -170,20 +174,7 @@ export const oauthHandler: HttpFunction = async (req, res) => {
 
     throw new MethodNotAllowedError("Method Not Allowed");
   } catch (error: any) {
-    console.error("Unhandled error in oauthHandler:", error);
-    if (error.statusCode) {
-      res.status(error.statusCode).json({ error: error.message });
-      return;
-    } else if (
-      error.message.includes("ID token") ||
-      error.message.includes("Unauthorized")
-    ) {
-      res.status(401).json({ error: error.message });
-      return;
-    }
-    res
-      .status(500)
-      .json({ error: error.message || "An internal server error occurred." });
+    handleError(res, error);
     return;
   }
 };

--- a/backend/src/utils/errors.ts
+++ b/backend/src/utils/errors.ts
@@ -104,6 +104,7 @@ export const handleError = (res: Response, error: unknown): void => {
   }
 
   // 特定のエラーメッセージパターンに対する互換性維持
+  // errorがErrorオブジェクトの場合はmessageを取得、それ以外（文字列など）はString変換
   const errorMessage = error instanceof Error ? error.message : String(error);
 
   if (

--- a/backend/src/utils/errors.ts
+++ b/backend/src/utils/errors.ts
@@ -1,3 +1,5 @@
+import type { Response } from "express";
+
 /**
  * アプリケーション内で使用するカスタムエラーの基底クラス。
  * HTTPステータスコードを保持する `statusCode` プロパティを追加し、
@@ -83,7 +85,7 @@ export class MethodNotAllowedError extends CustomError {
  * @param res Expressのレスポンスオブジェクト
  * @param error 発生したエラーオブジェクト
  */
-export const handleError = (res: any, error: any): void => {
+export const handleError = (res: Response, error: unknown): void => {
   // エラーの詳細をサーバーログに出力 (重要)
   console.error("Error caught in handler:", error);
 
@@ -102,7 +104,8 @@ export const handleError = (res: any, error: any): void => {
   }
 
   // 特定のエラーメッセージパターンに対する互換性維持
-  const errorMessage = error.message || "";
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
   if (
     errorMessage.includes("ID token") ||
     errorMessage.includes("Unauthorized")

--- a/backend/test/foodlog.test.ts
+++ b/backend/test/foodlog.test.ts
@@ -108,11 +108,7 @@ describe("foodLogHandler", () => {
 
     await foodLogHandler(req, res);
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: expect.stringContaining("Invalid ID token"),
-      }),
-    );
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
   });
 
   it("should return 400 for invalid body (missing foods)", async () => {
@@ -253,7 +249,7 @@ describe("foodLogHandler", () => {
     expect(res.status).toHaveBeenCalledWith(500); // FitbitApiError defaults to 500
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
-        error: expect.stringContaining("Fitbit user ID not found"),
+        error: "An internal server error occurred.",
       }),
     );
   });
@@ -306,7 +302,7 @@ describe("foodLogHandler", () => {
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ error: "Fitbit API Down" }),
+      expect.objectContaining({ error: "An internal server error occurred." }),
     );
   });
 });

--- a/backend/test/oauth.test.ts
+++ b/backend/test/oauth.test.ts
@@ -68,23 +68,18 @@ describe("oauthHandler", () => {
     delete process.env.OAUTH_FITBIT_REDIRECT_URI;
     await oauthHandler(req, res);
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error: "OAUTH_FITBIT_REDIRECT_URI 環境変数が設定されていません。",
-      }),
-    );
+    expect(res.json).toHaveBeenCalledWith({
+      error: "An internal server error occurred.",
+    });
   });
 
   it("should throw error if FITBIT_CLIENT_ID or SECRET is missing", async () => {
     delete process.env.FITBIT_CLIENT_ID;
     await oauthHandler(req, res);
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error:
-          "FITBIT_CLIENT_ID and FITBIT_CLIENT_SECRET environment variables must be set",
-      }),
-    );
+    expect(res.json).toHaveBeenCalledWith({
+      error: "An internal server error occurred.",
+    });
   });
 
   it("should return 400 if state parameter is missing", async () => {
@@ -236,7 +231,7 @@ describe("oauthHandler", () => {
     await oauthHandler(req, res);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized access" });
+    expect(res.json).toHaveBeenCalledWith({ error: "Unauthorized" });
   });
 
   it("should handle arbitrary errors as 500", async () => {
@@ -252,6 +247,8 @@ describe("oauthHandler", () => {
     await oauthHandler(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: "Unknown error" });
+    expect(res.json).toHaveBeenCalledWith({
+      error: "An internal server error occurred.",
+    });
   });
 });


### PR DESCRIPTION
Sentinel セキュリティプロセスに基づき、バックエンドAPIのエラーハンドリングを強化しました。

## 🛡️ セキュリティ改善 (Enhancement)

### 目的
予期せぬサーバーエラーが発生した際に、スタックトレースや内部エラーメッセージがクライアントに送信されることを防ぎ、潜在的な情報漏洩リスクを低減する。

### 変更内容
1.  **共通エラーハンドラの導入 (`backend/src/utils/errors.ts`)**
    *   `handleError` 関数を追加し、エラー処理ロジックを統一。
    *   500以上のステータスコード、または予期せぬエラーの場合、クライアントには汎用メッセージ (`An internal server error occurred.`) のみを返すように変更。
    *   詳細なエラー内容はサーバーログ (`console.error`) に記録。
    *   400番台のクライアントエラーは、引き続き有用なエラーメッセージを返す。

2.  **ハンドラの修正 (`backend/src/handlers/oauth.ts`, `backend/src/handlers/foodlog.ts`)**
    *   個別の `try-catch` ブロック内のエラー処理を `handleError` 関数に置き換え。

3.  **テストの更新 (`backend/test/oauth.test.ts`, `backend/test/foodlog.test.ts`)**
    *   セキュリティ強化に伴い、500エラー時のレスポンス期待値を汎用メッセージに変更。

### 検証
*   `pnpm --filter backend run test` を実行し、全てのテストがパスすることを確認しました。

---
*PR created automatically by Jules for task [2776946493666957059](https://jules.google.com/task/2776946493666957059) started by @viv-devel*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * エラーハンドリングを一元化し、公開されるエラーメッセージを安全かつ統一された文言にしました。内部の詳細はログに残します。

* **テスト**
  * 一元化されたエラーハンドリングに合わせてテストを更新し、期待されるエラーレスポンスの文言を一般化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->